### PR TITLE
fix(ui): improve responsiveness for small terminal sizes

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -50,7 +50,17 @@ func (m model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m model) renderWithDetailOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 72)
-	modalHeight := m.height - 6
+	// modalHeight: try to leave some margin, but don't exceed screen and don't go too small
+	modalHeight := m.height - 2
+	if modalHeight < 8 && m.height >= 8 {
+		modalHeight = 8
+	}
+	if modalHeight > m.height {
+		modalHeight = m.height
+	}
+	if modalHeight < 1 {
+		modalHeight = 1
+	}
 
 	// Use displayRows (full columns) instead of m.table.Rows() (windowed)
 	sourceRows := m.displayRows
@@ -74,7 +84,7 @@ func (m model) renderWithDetailOverlay(background string) string {
 
 	valueStyle := lipgloss.NewStyle().
 		Foreground(textColor).
-		Width(modalWidth - 6)
+		Width(max(modalWidth-6, 10))
 
 	selectedLabelStyle := lipgloss.NewStyle().
 		Foreground(accentColor).
@@ -83,13 +93,14 @@ func (m model) renderWithDetailOverlay(background string) string {
 	selectedValueStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(lipgloss.Color("#1E293B")).
-		Width(modalWidth - 6)
+		Width(max(modalWidth-6, 10))
 
 	title := titleStyle.Render(fmt.Sprintf("Row %d/%d", rowIdx+1, totalRows))
 
 	// Calculate scroll offset so cursor stays visible
-	contentHeight := max(modalHeight-3, 1) // title + margins
-	linesPerField := 3                     // label line + value line + separator
+	// contentHeight: total modal height minus borders(2), padding(2), and title area(2)
+	contentHeight := max(modalHeight-6, 1)
+	linesPerField := 3 // label line + value line + separator
 	maxVisibleFields := max(contentHeight/linesPerField, 1)
 	if m.detail.fieldCursor >= m.detail.scroll+maxVisibleFields {
 		m.detail.scroll = m.detail.fieldCursor - maxVisibleFields + 1

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -50,17 +50,9 @@ func (m model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m model) renderWithDetailOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 72)
-	// modalHeight: try to leave some margin, but don't exceed screen and don't go too small
-	modalHeight := m.height - 2
-	if modalHeight < 8 && m.height >= 8 {
-		modalHeight = 8
-	}
-	if modalHeight > m.height {
-		modalHeight = m.height
-	}
-	if modalHeight < 1 {
-		modalHeight = 1
-	}
+	// boxStyle below applies a rounded border (adds 2 rows) on top of Height(modalHeight).
+	// Cap modalHeight to m.height-2 so the rendered modal never overflows the screen.
+	modalHeight := max(m.height-2, 1)
 
 	// Use displayRows (full columns) instead of m.table.Rows() (windowed)
 	sourceRows := m.displayRows

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -544,7 +544,10 @@ func (m model) View() string {
 		view = m.renderWithProfileOverlay(view)
 	}
 
-	return view
+	return lipgloss.NewStyle().
+		MaxHeight(m.height).
+		MaxWidth(m.width).
+		Render(view)
 }
 
 func (m *model) contentWidth() int {
@@ -590,15 +593,15 @@ func (m *model) resize() {
 	contentWidth := m.contentWidth() // half if compare active
 
 	m.textarea.SetWidth(max(fullWidth-4, 20))
-	m.textarea.SetHeight(max(editorHeight-2, 5))
+	m.textarea.SetHeight(max(editorHeight-2, 1))
 
 	if m.pinned != nil {
 		compareHeight := resultsHeight - 1 // subtract label row
-		m.table.SetHeight(max(compareHeight-4, 3))
-		m.pinned.table.SetHeight(max(compareHeight-4, 3))
+		m.table.SetHeight(max(compareHeight-4, 1))
+		m.pinned.table.SetHeight(max(compareHeight-4, 1))
 		m.pinned.viewportDirty = true
 	} else {
-		m.table.SetHeight(max(resultsHeight-4, 3))
+		m.table.SetHeight(max(resultsHeight-4, 1))
 	}
 	m.viewport.Width = contentWidth
 	m.viewport.Height = resultsHeight
@@ -608,13 +611,35 @@ func (m *model) resize() {
 }
 
 func (m *model) editorHeight() int {
-	available := max(m.height-1, 6)
-	return max(int(float64(available)*0.3), 7)
+	// Account for 1 status bar row and 2 JoinVertical newlines
+	available := max(m.height-3, 0)
+	if available <= 0 {
+		return 0
+	}
+	h := int(float64(available) * 0.3)
+	// On very small screens, ensure we don't exceed available height
+	// while still trying to provide at least some space for the editor.
+	if h < 3 && available >= 3 {
+		h = 3
+	} else if h < 1 {
+		h = 1
+	}
+	if h > available {
+		h = available
+	}
+	return h
 }
 
 func (m *model) resultsHeight() int {
-	available := max(m.height-1, 6)
-	return max(available-m.editorHeight(), 4)
+	available := max(m.height-3, 0)
+	if available <= 0 {
+		return 0
+	}
+	eh := m.editorHeight()
+	if eh >= available {
+		return 0
+	}
+	return available - eh
 }
 
 func (m *model) setStatus(text string, isError bool) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -617,15 +617,15 @@ func (m *model) editorHeight() int {
 		return 0
 	}
 	h := int(float64(available) * 0.3)
-	// On very small screens, ensure we don't exceed available height
-	// while still trying to provide at least some space for the editor.
-	if h < 3 && available >= 3 {
+	// Boost editor to a minimum usable size only when the results pane can
+	// still keep at least one row; otherwise prefer preserving results.
+	if h < 3 && available >= 4 {
 		h = 3
 	} else if h < 1 {
 		h = 1
 	}
-	if h > available {
-		h = available
+	if h >= available {
+		h = max(available-1, 1)
 	}
 	return h
 }

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -103,13 +103,15 @@ func (m model) updateStats(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // statsMaxVisible returns the number of stat rows visible in the overlay,
 // accounting for the extra line when the cursor row has a sparkline or histogram.
 func (m model) statsMaxVisible() int {
-	v := max(m.height-10, 3)
+	// Fixed overhead: border(2), padding(2), title(1), separator(1), header(1) = 7 lines.
+	available := max(m.height-7, 1)
+	v := available
 	if m.statsSt.cursor < len(m.statsSt.stats) {
 		s := m.statsSt.stats[m.statsSt.cursor]
 		hasExtra := s.Sparkline.Bars != "" || s.Sparkline.Skipped ||
 			s.Histogram.Bars != "" || s.Histogram.Skipped
 		if hasExtra {
-			v = max(v-1, 2)
+			v = max(v-1, 1)
 		}
 	}
 	return v


### PR DESCRIPTION
This PR improves the stability and responsiveness of the UI when the terminal size is small or resized to extreme dimensions.

Key changes:
- **Dynamic height allocation ():** Re-engineered the calculation for editor and results areas to accurately account for the status bar and layout overhead, ensuring they always fit within the terminal height.
- **Physical overflow prevention:** Applied  and  constraints to the final View output to prevent terminal overflow caused by inner component borders or padding.
- **Improved Overlays (, ):** Limited the height of Detail and Stats modals to stay within screen bounds and correctly re-calculate scrollable areas.
- **Relaxed component constraints:** Lowered minimum height requirements for textarea and table components to allow for more flexible rendering in tight spaces.

Verified on multiple terminal sizes (80x24, 60x12, 40x8, 40x5) via unit tests.