### PR TITLE
fix(ui): harden TUI layout for narrow terminals and mode transitions

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -655,3 +655,25 @@ if err != nil {
 - **ルール**: `go install github.com/goreleaser/goreleaser/v2@latest` で `$(go env GOPATH)/bin/goreleaser` に入る。`~/go/bin` が PATH に無ければ絶対パス `~/go/bin/goreleaser` で実行する
 
 ---
+
+## TUI レイアウト・モード遷移 (2026-04-30)
+
+### Bubble Tea の View() は純粋関数として保つ
+- `renderCompareView` が `View()` 経路から `syncPinnedTable` を呼んでテーブル状態を変異させていた。レンダリングごとに pinned テーブルが書き換わり、不定期な再描画バグの温床になる
+- **ルール**: View() および View() から呼ばれる関数は読み取り専用にする。テーブル/ビューポート同期は `Update`・`resize`・結果適用時 (`applyResult` 後) などのイベントパスに移し、共通ヘルパー（例: `syncCompareTables()`）に集約する
+
+### TUI 幅計算では `available <= 0` と固定オフセットの負値を必ずガードする
+- `visibleColumnRange` が `available := contentWidth() - 8` を負/ゼロでもループに突入し、最初のカラムを強制描画してレイアウト崩れを起こしていた。同様に `maxVisible := height - 2` もクランプなしで負値になり得た
+- **ルール**: `width - N` / `height - N` などのオフセット計算は (1) 結果が `<= 0` のとき早期 return か空範囲を返す、(2) 後段で使う場合は `max(value, 0)` または `max(value, 1)` でクランプする。1行の `max()` で済むのでケチらない
+
+### モーダル overlay の入力幅は `calcModalWidth` から動的に同期する
+- AI/Snippet/Profile overlay の `textinput.Width` が `50`/`30` の固定値で、`modalWidth` の縮小に追従せず狭画面で入力欄がモーダルからはみ出していた
+- **ルール**: `renderWith*Overlay` で `modalWidth := calcModalWidth(m.width, ...)` を計算した直後に `m.xxxSt.input.Width = max(modalWidth-12, 1)` を設定してから描画する。`calcModalWidth` 自身も `min(20, max(screenWidth, 1))` で実画面幅を下限に取る
+
+### モード遷移時の Blur は専用ヘルパーで集約する
+- Ctrl+C グローバルキャンセル時、`m.textarea.Blur()` だけ呼んでいたため AI/Snippet/Profile/HistorySearch モードの input がフォーカス残留していた
+- **ルール**: `blurActiveInput()` のように現在の mode に対応する input を Blur する単一メソッドを用意し、グローバルキャンセル・mode 遷移直前に呼ぶ。新しい入力フィールドを持つモードを追加したら必ずこのヘルパーに分岐を追加する
+
+### Codex の sandbox モードは `--resume` では切り替わらない
+- 前回 read-only sandbox で起動した Codex タスクを `--resume` で再開しても read-only のままで、ファイル書き込みが必要なフォローアップタスクが失敗した
+- **ルール**: 前回タスクが調査・読み取りで起動していた場合、書き込みを伴う続行タスクは `--fresh` で再投入する。Codex は前回スレッドの分析を保持しているので、同じ指示を新スレッドで投げ直して問題ない

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -666,9 +666,9 @@ if err != nil {
 - `visibleColumnRange` が `available := contentWidth() - 8` を負/ゼロでもループに突入し、最初のカラムを強制描画してレイアウト崩れを起こしていた。同様に `maxVisible := height - 2` もクランプなしで負値になり得た
 - **ルール**: `width - N` / `height - N` などのオフセット計算は (1) 結果が `<= 0` のとき早期 return か空範囲を返す、(2) 後段で使う場合は `max(value, 0)` または `max(value, 1)` でクランプする。1行の `max()` で済むのでケチらない
 
-### モーダル overlay の入力幅は `calcModalWidth` から動的に同期する
-- AI/Snippet/Profile overlay の `textinput.Width` が `50`/`30` の固定値で、`modalWidth` の縮小に追従せず狭画面で入力欄がモーダルからはみ出していた
-- **ルール**: `renderWith*Overlay` で `modalWidth := calcModalWidth(m.width, ...)` を計算した直後に `m.xxxSt.input.Width = max(modalWidth-12, 1)` を設定してから描画する。`calcModalWidth` 自身も `min(20, max(screenWidth, 1))` で実画面幅を下限に取る
+### モーダル overlay の入力幅は `resize()` で `calcModalWidth` から同期する
+- AI/Snippet/Profile overlay の `textinput.Width` が `50`/`30` の固定値で、`modalWidth` の縮小に追従せず狭画面で入力欄がモーダルからはみ出していた。一度は `renderWith*Overlay` 内で `m.xxxSt.input.Width = ...` を設定して直したが、これは「View() は純粋関数として保つ」ルールに反する状態変異だった
+- **ルール**: モーダル入力幅の同期は `resize()` の末尾に集約し、`m.xxxSt.input.Width = max(calcModalWidth(m.width, N)-K, min)` を一括で更新する。`renderWith*Overlay` は `modalWidth` を計算しても `input.Width` には書き込まない（読み取りのみ）。`calcModalWidth` 自身も `min(20, max(screenWidth, 1))` で実画面幅を下限に取る
 
 ### モード遷移時の Blur は専用ヘルパーで集約する
 - Ctrl+C グローバルキャンセル時、`m.textarea.Blur()` だけ呼んでいたため AI/Snippet/Profile/HistorySearch モードの input がフォーカス残留していた

--- a/internal/ui/ai.go
+++ b/internal/ui/ai.go
@@ -74,7 +74,6 @@ func generateSQLCmd(parent context.Context, client *ai.Client, adapter db.DBAdap
 
 func (m model) renderWithAIOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
-	m.aiSt.input.Width = max(modalWidth-12, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).

--- a/internal/ui/ai.go
+++ b/internal/ui/ai.go
@@ -23,6 +23,7 @@ func (m model) updateAI(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.queryCancel = nil
 			}
 			m.aiSt.loading = false
+			m.aiSt.input.Blur()
 			m.mode = normalMode
 			m.setStatus("Cancelled", false)
 			return m, nil
@@ -31,6 +32,7 @@ func (m model) updateAI(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.Type {
 	case tea.KeyEsc:
+		m.aiSt.input.Blur()
 		m.mode = normalMode
 		m.aiSt.err = ""
 		m.setStatus("Normal mode", false)
@@ -72,6 +74,7 @@ func generateSQLCmd(parent context.Context, client *ai.Client, adapter db.DBAdap
 
 func (m model) renderWithAIOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
+	m.aiSt.input.Width = max(modalWidth-12, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).

--- a/internal/ui/compare.go
+++ b/internal/ui/compare.go
@@ -180,9 +180,12 @@ func (p *pinnedPane) visibleColumnRange(availWidth int) (int, int) {
 	if start >= len(p.colWidths) {
 		start = 0
 	}
+	if available <= 0 {
+		return start, min(start+1, len(p.colWidths))
+	}
 	sum := 0
 	for i := start; i < len(p.colWidths); i++ {
-		w := p.colWidths[i] + 1
+		w := min(p.colWidths[i], available) + 1
 		if sum+w > available && i > start {
 			return start, i
 		}
@@ -264,7 +267,7 @@ func (m *model) syncPinnedTable(paneWidth, paneHeight int) {
 		if m.comparePane == 0 && i == p.colCursor {
 			header = selectedStyle.Render(header)
 		}
-		columns = append(columns, table.Column{Title: header, Width: p.colWidths[i]})
+		columns = append(columns, table.Column{Title: header, Width: min(p.colWidths[i], max(paneWidth-8, 1))})
 	}
 
 	rows := make([]table.Row, 0, len(p.displayRows))
@@ -295,12 +298,17 @@ func (m *model) syncPinnedTable(paneWidth, paneHeight int) {
 	p.viewportDirty = false
 }
 
+func (m *model) syncCompareTables() {
+	if m.pinned == nil {
+		return
+	}
+	m.syncPinnedTable(m.comparePaneWidth(), m.resultsHeight()-1)
+}
+
 // renderCompareView renders side-by-side panels.
 func (m *model) renderCompareView() string {
 	paneWidth := m.comparePaneWidth()
 	paneHeight := m.resultsHeight() - 1 // subtract 1 for label row
-
-	m.syncPinnedTable(paneWidth, paneHeight)
 
 	focusedBorder := lipgloss.Color("#38BDF8") // accentColor
 	unfocusedBorder := panelBorder

--- a/internal/ui/completion.go
+++ b/internal/ui/completion.go
@@ -366,18 +366,20 @@ func (m model) renderCompletionPopup() string {
 	if popupWidth > 50 {
 		popupWidth = 50
 	}
+	popupWidth = min(popupWidth, max(m.fullContentWidth()-4, 1))
+	popupInnerWidth := max(popupWidth-4, 1)
 
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(popupWidth - 4).
+		Width(popupInnerWidth).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(popupWidth - 4).
+		Width(popupInnerWidth).
 		Padding(0, 1)
 
 	// Calculate scroll offset
@@ -406,7 +408,7 @@ func (m model) renderCompletionPopup() string {
 		info := lipgloss.NewStyle().
 			Foreground(mutedTextColor).
 			Background(panelBackground).
-			Width(popupWidth - 4).
+			Width(popupInnerWidth).
 			Padding(0, 1).
 			Render(fmt.Sprintf("%d/%d", m.completion.cursor+1, len(m.completion.items)))
 		lines = append(lines, info)

--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -96,6 +96,7 @@ func (m *model) executeExport() {
 
 func (m model) renderWithExportOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 40)
+	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -112,14 +113,14 @@ func (m model) renderWithExportOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth - 6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/histogram_test.go
+++ b/internal/ui/histogram_test.go
@@ -21,7 +21,7 @@ func TestDetectNumericColumn(t *testing.T) {
 		{"DECIMAL", true},
 		{"NUMERIC", true},
 		{"NUMBER", true},
-		{"integer", true},    // lowercase
+		{"integer", true}, // lowercase
 		{"int unsigned", true},
 		{"double precision", true},
 		{"TEXT", false},
@@ -29,8 +29,8 @@ func TestDetectNumericColumn(t *testing.T) {
 		{"DATE", false},
 		{"TIMESTAMP", false},
 		{"BLOB", false},
-		{"INTERVAL", false},   // must not match "int" substring
-		{"POINT", false},      // must not match "int" substring
+		{"INTERVAL", false}, // must not match "int" substring
+		{"POINT", false},    // must not match "int" substring
 		{"interval", false},
 		{"", false},
 	}
@@ -145,7 +145,7 @@ func TestComputeHistogram(t *testing.T) {
 			rows: func() [][]string {
 				r := make([][]string, 0, 100)
 				for i := 0; i < 100; i++ {
-					r = append(r, []string{string(rune('0'+i%10))})
+					r = append(r, []string{string(rune('0' + i%10))})
 				}
 				// Use explicit values instead
 				return [][]string{

--- a/internal/ui/history_search.go
+++ b/internal/ui/history_search.go
@@ -107,8 +107,6 @@ func (m model) renderWithHistorySearchOverlay(background string) string {
 
 	var items strings.Builder
 
-	// Search input — adapt width to modal
-	m.histSearch.input.Width = max(modalWidth-10, 10)
 	items.WriteString(lipgloss.NewStyle().Foreground(textColor).Background(panelBackground).Render("> "))
 	items.WriteString(m.histSearch.input.View())
 	items.WriteByte('\n')

--- a/internal/ui/history_search.go
+++ b/internal/ui/history_search.go
@@ -78,6 +78,7 @@ func (m model) enterHistorySearchMode() (tea.Model, tea.Cmd) {
 
 func (m model) renderWithHistorySearchOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
+	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -94,14 +95,14 @@ func (m model) renderWithHistorySearchOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth - 6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -634,6 +634,13 @@ func (m *model) resize() {
 	m.viewportDirty = true
 	m.syncViewport()
 	m.syncCompareTables()
+
+	// Sync modal input widths so View() can stay a pure read.
+	// Keep these in sync with calcModalWidth args used by renderWith*Overlay.
+	m.aiSt.input.Width = max(calcModalWidth(m.width, 60)-12, 1)
+	m.snippetSt.input.Width = max(calcModalWidth(m.width, 50)-12, 1)
+	m.profileSt.input.Width = max(calcModalWidth(m.width, 60)-12, 1)
+	m.histSearch.input.Width = max(calcModalWidth(m.width, 60)-10, 10)
 }
 
 func (m *model) editorHeight() int {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -282,6 +282,23 @@ func (m model) Init() tea.Cmd {
 	return tea.Batch(textarea.Blink, loadTablesCmd(m.connMgr.Active()))
 }
 
+func (m *model) blurActiveInput() {
+	switch m.mode {
+	case insertMode:
+		m.textarea.Blur()
+	case aiMode:
+		m.aiSt.input.Blur()
+	case snippetMode:
+		m.snippetSt.input.Blur()
+	case profileMode:
+		m.profileSt.input.Blur()
+	case historySearchMode:
+		m.histSearch.input.Blur()
+	default:
+		m.textarea.Blur()
+	}
+}
+
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -295,8 +312,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.queryCancel()
 				m.queryCancel = nil
 				m.aiSt.loading = false
+				m.blurActiveInput()
 				m.mode = normalMode
-				m.textarea.Blur()
 				m.setStatus("Cancelled", false)
 				return m, nil
 			}
@@ -304,7 +321,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch m.mode {
 		case normalMode:
-			return m.updateNormal(msg)
+			next, cmd := m.updateNormal(msg)
+			if updated, ok := next.(model); ok {
+				updated.syncCompareTables()
+				return updated, cmd
+			}
+			return next, cmd
 		case insertMode:
 			return m.updateInsert(msg)
 		case sidebarMode:
@@ -338,6 +360,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.textarea.SetValue(msg.sql)
+		m.aiSt.input.Blur()
 		m.mode = insertMode
 		m.textarea.Focus()
 		m.setStatus("AI generated SQL — review before executing", false)
@@ -449,6 +472,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.colCursor = 0
 		m.colOffset = 0
 		m.applyResult(msg.result)
+		m.syncCompareTables()
 		if m.pinned != nil {
 			m.setStatus(m.compareStatusSummary(), false)
 		}
@@ -472,6 +496,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// no passthrough needed
 	}
 	m.syncViewport()
+	m.syncCompareTables()
 	return m, cmd
 }
 
@@ -608,6 +633,7 @@ func (m *model) resize() {
 
 	m.viewportDirty = true
 	m.syncViewport()
+	m.syncCompareTables()
 }
 
 func (m *model) editorHeight() int {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -83,13 +83,13 @@ func newTestModel() *model {
 	vp := viewport.New(0, 0)
 	ta := textarea.New()
 	return &model{
-		connMgr:            newConnManager("test", "", nil),
-		table:              tbl,
-		viewport:           vp,
-		textarea:           ta,
-		width:              80,
-		height:             24,
-		historyIdx:         -1,
+		connMgr:    newConnManager("test", "", nil),
+		table:      tbl,
+		viewport:   vp,
+		textarea:   ta,
+		width:      80,
+		height:     24,
+		historyIdx: -1,
 		histSearch: histSearchState{input: textinput.New()},
 	}
 }

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -3,11 +3,12 @@ package ui
 import "github.com/charmbracelet/lipgloss"
 
 // calcModalWidth computes the modal width from the screen width and a maximum.
-// The result is clamped to at least 20.
+// The result is clamped to at least 20 when the screen is wide enough.
 func calcModalWidth(screenWidth, maxWidth int) int {
 	w := min(screenWidth-4, maxWidth)
-	if w < 20 {
-		w = 20
+	minWidth := min(20, max(screenWidth, 1))
+	if w < minWidth {
+		w = minWidth
 	}
 	return w
 }

--- a/internal/ui/profile.go
+++ b/internal/ui/profile.go
@@ -129,6 +129,7 @@ func (m model) switchProfile(p profile.Profile, reExecute bool) (tea.Model, tea.
 func (m model) renderWithProfileOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
 	m.profileSt.input.Width = max(modalWidth-12, 1)
+	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -145,20 +146,20 @@ func (m model) renderWithProfileOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	dsnPreviewStyle := lipgloss.NewStyle().
 		Foreground(mutedTextColor).
 		Background(panelBackground).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/profile.go
+++ b/internal/ui/profile.go
@@ -128,7 +128,6 @@ func (m model) switchProfile(p profile.Profile, reExecute bool) (tea.Model, tea.
 
 func (m model) renderWithProfileOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
-	m.profileSt.input.Width = max(modalWidth-12, 1)
 	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().

--- a/internal/ui/profile.go
+++ b/internal/ui/profile.go
@@ -128,6 +128,7 @@ func (m model) switchProfile(p profile.Profile, reExecute bool) (tea.Model, tea.
 
 func (m model) renderWithProfileOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 60)
+	m.profileSt.input.Width = max(modalWidth-12, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -144,20 +145,20 @@ func (m model) renderWithProfileOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	dsnPreviewStyle := lipgloss.NewStyle().
 		Foreground(mutedTextColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/result.go
+++ b/internal/ui/result.go
@@ -32,9 +32,12 @@ func (m *model) visibleColumnRange() (int, int) {
 	if start >= len(m.cachedColWidths) {
 		start = 0
 	}
+	if available <= 0 {
+		return start, min(start+1, len(m.cachedColWidths))
+	}
 	sum := 0
 	for i := start; i < len(m.cachedColWidths); i++ {
-		w := m.cachedColWidths[i] + 1 // column width + cell gap
+		w := min(m.cachedColWidths[i], available) + 1 // column width + cell gap
 		if sum+w > available && i > start {
 			return start, i
 		}
@@ -82,7 +85,7 @@ func (m *model) syncViewport() {
 			if m.mode == normalMode && i == m.colCursor && (m.pinned == nil || m.comparePane == 1) {
 				header = selectedStyle.Render(header)
 			}
-			columns = append(columns, table.Column{Title: header, Width: m.cachedColWidths[i]})
+			columns = append(columns, table.Column{Title: header, Width: min(m.cachedColWidths[i], max(m.contentWidth()-8, 1))})
 		}
 
 		// Build windowed rows with sanitized cell values

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -81,7 +81,7 @@ func (m model) renderSidebar() string {
 	lines := 1
 
 	// Calculate scroll offset so cursor stays visible
-	maxVisible := height - 2 // title line + border allowance
+	maxVisible := max(height-2, 0) // title line + border allowance
 	scrollOffset := 0
 	if maxVisible > 0 && m.sidebar.cursor >= maxVisible {
 		scrollOffset = m.sidebar.cursor - maxVisible + 1

--- a/internal/ui/snippet.go
+++ b/internal/ui/snippet.go
@@ -153,6 +153,7 @@ func (m model) updateSnippetNaming(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m model) renderWithSnippetOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 50)
 	m.snippetSt.input.Width = max(modalWidth-12, 1)
+	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -169,20 +170,20 @@ func (m model) renderWithSnippetOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	queryPreviewStyle := lipgloss.NewStyle().
 		Foreground(mutedTextColor).
 		Background(panelBackground).
-		Width(modalWidth-6).
+		Width(innerWidth).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/snippet.go
+++ b/internal/ui/snippet.go
@@ -152,7 +152,6 @@ func (m model) updateSnippetNaming(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m model) renderWithSnippetOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 50)
-	m.snippetSt.input.Width = max(modalWidth-12, 1)
 	innerWidth := max(modalWidth-6, 1)
 
 	titleStyle := lipgloss.NewStyle().

--- a/internal/ui/snippet.go
+++ b/internal/ui/snippet.go
@@ -152,6 +152,7 @@ func (m model) updateSnippetNaming(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m model) renderWithSnippetOverlay(background string) string {
 	modalWidth := calcModalWidth(m.width, 50)
+	m.snippetSt.input.Width = max(modalWidth-12, 1)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -168,20 +169,20 @@ func (m model) renderWithSnippetOverlay(background string) string {
 	itemStyle := lipgloss.NewStyle().
 		Foreground(textColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	selectedStyle := lipgloss.NewStyle().
 		Foreground(panelBackground).
 		Background(accentColor).
 		Bold(true).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	queryPreviewStyle := lipgloss.NewStyle().
 		Foreground(mutedTextColor).
 		Background(panelBackground).
-		Width(modalWidth - 6).
+		Width(modalWidth-6).
 		Padding(0, 1)
 
 	var items strings.Builder

--- a/internal/ui/sparkline.go
+++ b/internal/ui/sparkline.go
@@ -62,7 +62,7 @@ const (
 )
 
 const (
-	dayGranularityThreshold  = 90 * 24 * time.Hour
+	dayGranularityThreshold   = 90 * 24 * time.Hour
 	monthGranularityThreshold = 730 * 24 * time.Hour
 )
 

--- a/internal/ui/sparkline_test.go
+++ b/internal/ui/sparkline_test.go
@@ -35,12 +35,12 @@ func TestParseDate(t *testing.T) {
 		input string
 		ok    bool
 	}{
-		{"2024-01-15T10:30:00Z", true},          // RFC3339
-		{"2024-01-15T10:30:00+09:00", true},      // RFC3339 with offset
-		{"2024-01-15T10:30:00", true},             // ISO 8601 no TZ
-		{"2024-01-15 10:30:00", true},             // datetime
-		{"2024-01-15", true},                      // date only
-		{"2024/01/15", true},                      // slash
+		{"2024-01-15T10:30:00Z", true},      // RFC3339
+		{"2024-01-15T10:30:00+09:00", true}, // RFC3339 with offset
+		{"2024-01-15T10:30:00", true},       // ISO 8601 no TZ
+		{"2024-01-15 10:30:00", true},       // datetime
+		{"2024-01-15", true},                // date only
+		{"2024/01/15", true},                // slash
 		{"not-a-date", false},
 		{"12345", false},
 		{"", false},
@@ -249,4 +249,3 @@ func TestComputeColumnStats_TextLooksLikeDate(t *testing.T) {
 		t.Error("TEXT column with date values should have sparkline bars")
 	}
 }
-

--- a/internal/ui/states.go
+++ b/internal/ui/states.go
@@ -95,8 +95,8 @@ type columnStat struct {
 	Distinct  int
 	Min       string
 	Max       string
-	Sparkline sparklineData  // non-empty only for date/timestamp columns
-	Histogram histogramData  // non-empty only for numeric columns
+	Sparkline sparklineData // non-empty only for date/timestamp columns
+	Histogram histogramData // non-empty only for numeric columns
 }
 
 // statsState holds state for the column-statistics overlay (STATS mode).


### PR DESCRIPTION
## Summary
- Codex レビューで検出した internal/ui/ のレイアウト問題 11 件をまとめて修正
- 狭いターミナルでのカラム/ポップアップ/モーダル幅のオーバーフロー、`maxVisible` 負値、Ctrl+C 時の Blur 漏れ、`renderCompareView` の View 内状態変異を解消
- 自己レビューで追加発見した overlay 内幅クランプ漏れ (`Width(modalWidth-6)` の負値) と `gofmt -l internal/ui` 未適用ファイルも合わせて修正
- 新たに得た知見を LESSONS.md に追記（View 純粋化 / 幅計算ガード / モーダル input の動的同期 / モード別 Blur ヘルパー / Codex `--resume` の sandbox 継承）

## Test plan
- [ ] `go vet ./...` がクリーン
- [ ] `go test ./...` が通る（`internal/ai/TestGenerateSQL` の httptest sandbox 依存失敗を除く）
- [ ] `gofmt -l internal/ui/` が空
- [ ] 狭いターミナル（横 ~30 列、縦 ~10 行）で起動し、サイドバー / 結果テーブル / モーダル (AI/Snippet/Profile/Export/History) の描画がはみ出さないこと
- [ ] AI モード中に Ctrl+C を押すと normalMode に戻り `m.aiSt.input` がフォーカスを失うこと
- [ ] compare モードで結果再実行・リサイズ後にピン留めペインが正しく更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)