### PR TITLE
docs: update PLAN/LESSONS after PR #44 merge

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -677,3 +677,17 @@ if err != nil {
 ### Codex の sandbox モードは `--resume` では切り替わらない
 - 前回 read-only sandbox で起動した Codex タスクを `--resume` で再開しても read-only のままで、ファイル書き込みが必要なフォローアップタスクが失敗した
 - **ルール**: 前回タスクが調査・読み取りで起動していた場合、書き込みを伴う続行タスクは `--fresh` で再投入する。Codex は前回スレッドの分析を保持しているので、同じ指示を新スレッドで投げ直して問題ない
+
+## PR レビュー対応 (2026-04-30)
+
+### LESSONS.md にルールを追記する PR では、同じ PR 内に違反箇所が残っていないかを push 前に必ず grep する
+- PR #44 で「View() は純粋関数として保つ」ルールを LESSONS.md に追記したが、同 PR の `renderWithAIOverlay` / `renderWithSnippetOverlay` / `renderWithProfileOverlay` / `renderWithHistorySearchOverlay` 内で `m.xxxSt.input.Width = ...` を書き続けていた（= ルール違反 4 箇所）。gemini-code-assist bot の review-comment で 4 件まとめて指摘され、追加コミット (`ee39ea6`) で `resize()` 集約に直す羽目になった
+- **ルール**: ルールを LESSONS.md に追記したら、push する前に「ルール本文で禁じている書き方」（今回の例: `View()` 経路で `.input.Width =` / `.SetXXX(`）を `rg` で全検索し、違反候補を同 PR 内で全部潰す。レビューに通す前に自分で気づくこと
+
+### bot レビューでも「自家製ルール / 既存コードへの具体的参照」を含む指摘は人間レビュー同等に扱う
+- gemini-code-assist の指摘は `LESSONS.md (661行目) のルールに違反` と参照先を行番号で示しており、内容は完全に正確だった。「bot だから」とフィルタすると、自分で書いたばかりのルールへの違反を放置することになる
+- **ルール**: bot 指摘の優先度判断は「指摘が *この repo の* 規約・ファイル・行番号を具体的に参照しているか」で切り分ける。具体参照ありなら人間レビュー同等で対応、一般論的な命名・抽象化提案だけならスコープ外として却下してよい
+
+### `resolve-pr-comments` 後はマージ可否を `mergeStateStatus` で確認してから `--auto` でマージ予約する
+- PR #44 のレビュー対応コミットを push 直後、`mergeable: MERGEABLE / mergeStateStatus: UNSTABLE`（CI 進行中）の状態だった。手動で merge を待つより `gh pr merge --squash --auto --delete-branch` で予約するほうが、CI 完了即マージ＋ローカル/リモート両ブランチ削除まで一発で済む
+- **ルール**: レビュー対応 push 直後にマージしたい場合は (1) `gh pr view <N> --json mergeable,mergeStateStatus` で `MERGEABLE` を確認、(2) CI 進行中なら `gh pr merge <N> --squash --auto --delete-branch` で auto-merge 予約、(3) 完了後 `git fetch --prune` で remote-tracking 参照を整理する

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,25 +23,28 @@ Bring & Join (Phase 3) はまだ先。比較体験が磨き込まれてから。
 - テストカバレッジ拡充 (Issue #14, PR #35): MySQL/PostgreSQL アダプタ + UI (insert/sidebar/profile) テスト追加完了
 - Phase 4 完了: 4-1/4-2/4-3 Column Statistics Overlay (PR #36)、4-4 Sparkline (PR #38)、4-5 Histogram (PR #40)
 - コード品質改善 (PR #39): バグ修正・重複解消・パフォーマンス防御・設計改善
+- セキュリティ・安定性: Go toolchain pin to 1.26.2 (PR #42)、狭ターミナル応答性 (PR #43)、TUI レイアウト・モード遷移の堅牢化 (PR #44)
+- 最新リリース: v0.10.0
 - **次: Phase 3 (Bring & Join)**
 
-## 直近完了: コード品質・パフォーマンス改善 (PR #39)
+## 直近完了: TUI レイアウト・モード遷移の堅牢化 (PR #44)
 
 目的:
-- Codex 静的分析で特定されたバグ・重複・パフォーマンス問題を修正する
+- Codex レビューで検出した狭ターミナルでのレイアウト崩れとモード遷移時の状態残留を解消する
 
 主要ステップ:
-- [x] A1: stats.go `computeColumnStats` 境界チェック追加
-- [x] A2: sparkline.go `truncateTime`/`bucketKey` の panic をフォールバックに変更
-- [x] A3: AI エラーレスポンスの情報露出制限（構造化エラー抽出 + 200文字制限）
-- [x] B1: DB 接続生成を `internal/db/opener` パッケージに一本化
-- [x] B2: `containsReturning` を `dbutil.ContainsReturning` に共通化（~170行削減）
-- [x] C1: `ScanRows` に10,000行上限追加 + Stats 計算を `tea.Cmd` で非同期化
-- [x] D1: `config.Load()` の stderr 直出力を `Warnings` フィールドに変更
+- [x] `width - N` / `height - N` のオフセット計算に `<= 0` ガードと `max()` クランプを徹底
+- [x] AI/Snippet/Profile/HistorySearch の Blur を `blurActiveInput()` ヘルパーに集約
+- [x] モーダル overlay の `textinput.Width` を `resize()` で `calcModalWidth` から動的同期（`View()` の純粋性を回復）
+- [x] `renderCompareView` 等が View() 経路で行っていた状態変異を `Update`/`resize` に移動
+- [x] 新たな運用ルールを LESSONS.md に追記（View 純粋化 / 幅ガード / モーダル入力幅同期 / モード別 Blur ヘルパー）
 
 結果:
-- 18ファイル変更、+299/-247行
-- 全14パッケージのテスト・`go vet` パス
+- 17ファイル変更、+120/-48行
+- 全パッケージのテスト・`go vet` パス
+- 横 ~30 列、縦 ~10 行の狭画面で全モーダル（AI/Snippet/Profile/Export/History）が破綻せず描画可能
+
+過去の「直近完了」は `HISTORY.md` を参照（コード品質・パフォーマンス改善 PR #39 等）。
 
 ## Phase 2: Multi-DB Observation — 比較の完成（完了）
 


### PR DESCRIPTION
## Summary
- `PLAN.md`: 「直近完了」セクションを PR #39 → PR #44 (TUI レイアウト堅牢化) に差し替え、`現状` に PR #42/#43/#44 と v0.10.0 を追記
- `LESSONS.md`: PR #44 のレビュー対応で得た 3 件の教訓を追加 (ルール追記 PR の自己 grep / bot 指摘の優先度判断 / `gh pr merge --auto` の運用)

## Test plan
- [x] `git diff` でドキュメント差分のみであることを確認
- [x] PLAN.md の「直近完了」が最新 PR を反映
- [x] LESSONS.md の追加教訓が既存セクションと重複しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)