### PR TITLE
chore: untrack .codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ e2e/recordings/
 
 # AI tools
 .gemini/
+.codex
 status/
 !status/review.md
 


### PR DESCRIPTION
`.codex` は codex プラグインが作るローカルのマーカーファイル（0 バイト）で、PR #50 の作業開始時点では未追跡でした。私の `git add -A` が拾ってしまい、#50 に紛れて main に入っています。

インデックスから外し、`.gitignore` の「AI tools」セクション（`.gemini/` の隣）に追加します。ファイル自体はローカルに残るので、プラグインの動作には影響しません。

#50 の混入は私のミスです。作業ディレクトリの未追跡ファイルを確認せずに `git add -A` を使ったのが原因でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)